### PR TITLE
Fix memory layer serialization

### DIFF
--- a/src/juno/core/memory/memory_layer.py
+++ b/src/juno/core/memory/memory_layer.py
@@ -49,6 +49,13 @@ class MemoryLayer:
     def __init__(self, db_path: str = "juno_memory.db"):
         self.db_path = db_path
         self._init_database()
+
+    @staticmethod
+    def _json_serializer(obj: Any) -> Any:
+        """Serialize objects that are not JSON serializable by default."""
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return str(obj)
         
     def _init_database(self):
         """Initialize the memory database schema."""
@@ -97,12 +104,12 @@ class MemoryLayer:
             """, (
                 memory.id,
                 memory.memory_type.value,
-                json.dumps(memory.content),
-                json.dumps(memory.context),
+                json.dumps(memory.content, default=self._json_serializer),
+                json.dumps(memory.context, default=self._json_serializer),
                 memory.confidence,
                 memory.timestamp.isoformat(),
                 memory.expires_at.isoformat() if memory.expires_at else None,
-                json.dumps(memory.tags)
+                json.dumps(memory.tags, default=self._json_serializer)
             ))
             
             conn.commit()


### PR DESCRIPTION
## Summary
- handle datetimes when storing memory entries

## Testing
- `pytest tests/unit/test_reasoning_engine.py::TestReasoningEngine::test_confidence_calculation -q`
- `pytest tests/unit/test_memory_layer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68545d1528b08327ad30e02935bd9a2c