### PR TITLE
Fix tests README typo

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -281,4 +281,3 @@ python tests/metrics/coverage_analysis.py
 **Test Status**: ✅ Comprehensive Coverage  
 **Quality Assurance**: Enterprise-grade testing with 94.7% coverage  
 **Continuous Integration**: Automated testing on all commits
-mj3b


### PR DESCRIPTION
## Summary
- remove an extraneous line from `tests/README.md`

## Testing
- `pytest -k 'this_test_does_not_exist'` *(fails: ImportError: cannot import name 'ReasoningLevel', ModuleNotFoundError: No module named 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854633805b8832794e7ab049aedfe9e