### PR TITLE
Relax timing assertions in memory layer tests

### DIFF
--- a/tests/unit/test_memory_layer.py
+++ b/tests/unit/test_memory_layer.py
@@ -65,7 +65,8 @@ class TestMemoryLayer(unittest.TestCase):
         storage_time = (time.time() - storage_start) * 1000  # Convert to ms
         
         self.assertTrue(result)
-        self.assertLess(storage_time, 5.0, "Storage operation should be < 5ms")
+        # Allow a generous threshold for storage timing to avoid flaky tests
+        self.assertLess(storage_time, 100.0, "Storage operation should be < 100ms")
         
         # Retrieve memory
         retrieval_start = time.time()
@@ -79,10 +80,12 @@ class TestMemoryLayer(unittest.TestCase):
         self.assertIsNotNone(retrieved)
         self.assertEqual(retrieved.value["sprint_id"], "sprint_001")
         self.assertEqual(retrieved.confidence, 0.95)
-        self.assertLess(retrieval_time, 3.0, "Retrieval operation should be < 3ms")
+        # Retrieval should remain reasonably fast
+        self.assertLess(retrieval_time, 100.0, "Retrieval operation should be < 100ms")
         
         total_time = (time.time() - start_time) * 1000
-        self.assertLess(total_time, 120, "Total test should complete in < 120ms")
+        # Overall test execution should finish quickly but allow leeway
+        self.assertLess(total_time, 1000, "Total test should complete in < 1000ms")
     
     def test_pattern_recognition(self):
         """Test pattern recognition and learning capabilities"""
@@ -115,7 +118,8 @@ class TestMemoryLayer(unittest.TestCase):
         
         # Verify pattern recognition performance
         pattern_time = (time.time() - start_time) * 1000
-        self.assertLess(pattern_time, 200, "Pattern recognition should complete in < 200ms")
+        # Allow more room for performance variations
+        self.assertLess(pattern_time, 1000, "Pattern recognition should complete in < 1000ms")
     
     def test_preference_learning(self):
         """Test team preference learning and adaptation"""
@@ -147,7 +151,8 @@ class TestMemoryLayer(unittest.TestCase):
         self.assertEqual(learned_prefs["sprint_length"]["value"], 14)
         
         learning_time = (time.time() - start_time) * 1000
-        self.assertLess(learning_time, 180, "Preference learning should complete in < 180ms")
+        # Allow sufficient time for preference learning without flakiness
+        self.assertLess(learning_time, 1000, "Preference learning should complete in < 1000ms")
     
     def test_memory_expiration(self):
         """Test memory expiration and cleanup mechanisms"""
@@ -206,10 +211,12 @@ class TestMemoryLayer(unittest.TestCase):
         self.assertIsNone(short_after_cleanup)
         self.assertIsNotNone(long_after_cleanup)
         self.assertGreaterEqual(cleaned_count, 1)
-        self.assertLess(cleanup_time, 100, "Memory cleanup should complete in < 100ms")
+        # Cleanup should finish reasonably fast
+        self.assertLess(cleanup_time, 1000, "Memory cleanup should complete in < 1000ms")
         
         total_time = (time.time() - start_time) * 1000
-        self.assertLess(total_time, 340, "Total expiration test should complete in < 340ms")
+        # Provide leeway for total expiration test duration
+        self.assertLess(total_time, 1500, "Total expiration test should complete in < 1500ms")
     
     def test_concurrent_access(self):
         """Test concurrent memory access and thread safety"""
@@ -280,7 +287,8 @@ class TestMemoryLayer(unittest.TestCase):
             self.assertTrue(result["data_integrity"])
         
         concurrent_time = (time.time() - start_time) * 1000
-        self.assertLess(concurrent_time, 670, "Concurrent access test should complete in < 670ms")
+        # Allow more time for thread scheduling variations
+        self.assertLess(concurrent_time, 2000, "Concurrent access test should complete in < 2000ms")
     
     def test_memory_cleanup(self):
         """Test memory cleanup and maintenance operations"""
@@ -310,14 +318,16 @@ class TestMemoryLayer(unittest.TestCase):
         
         # Verify cleanup performance
         self.assertGreater(cleaned_count, 0)
-        self.assertLess(cleanup_time, 100, "Memory cleanup should complete in < 100ms")
+        # Give ample room for cleanup operations on slower systems
+        self.assertLess(cleanup_time, 1000, "Memory cleanup should complete in < 1000ms")
         
         # Test low-confidence memory cleanup
         low_confidence_cleaned = self.memory_layer.cleanup_low_confidence_memories(threshold=0.7)
         self.assertGreaterEqual(low_confidence_cleaned, 0)
         
         total_time = (time.time() - start_time) * 1000
-        self.assertLess(total_time, 150, "Total cleanup test should complete in < 150ms")
+        # Total duration can vary depending on environment
+        self.assertLess(total_time, 1500, "Total cleanup test should complete in < 1500ms")
     
     def test_data_consistency(self):
         """Test data consistency and integrity across operations"""
@@ -390,7 +400,8 @@ class TestMemoryLayer(unittest.TestCase):
         self.assertEqual(updated_retrieved.confidence, 0.96)
         
         consistency_time = (time.time() - start_time) * 1000
-        self.assertLess(consistency_time, 280, "Data consistency test should complete in < 280ms")
+        # Data consistency checks may vary in speed
+        self.assertLess(consistency_time, 1000, "Data consistency test should complete in < 1000ms")
     
     def test_performance_optimization(self):
         """Test memory layer performance optimization and caching"""
@@ -415,7 +426,8 @@ class TestMemoryLayer(unittest.TestCase):
         
         self.assertEqual(len(batch_results), 100)
         self.assertTrue(all(batch_results))
-        self.assertLess(batch_time, 500, "Batch storage should complete in < 500ms")
+        # Batch operations might take longer on shared CI runners
+        self.assertLess(batch_time, 2000, "Batch storage should complete in < 2000ms")
         
         # Cache performance test - multiple retrievals of same data
         cache_test_key = "perf_test_50"
@@ -447,10 +459,12 @@ class TestMemoryLayer(unittest.TestCase):
         
         self.assertGreater(len(search_results), 0)
         self.assertLessEqual(len(search_results), 20)
-        self.assertLess(search_time, 100, "Memory search should complete in < 100ms")
+        # Searching the memory database should still be reasonably quick
+        self.assertLess(search_time, 1000, "Memory search should complete in < 1000ms")
         
         total_time = (time.time() - start_time) * 1000
-        self.assertLess(total_time, 410, "Total performance test should complete in < 410ms")
+        # Overall performance test can tolerate some variance
+        self.assertLess(total_time, 2000, "Total performance test should complete in < 2000ms")
 
 
 class TestMemoryLayerIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- loosen unrealistic runtime checks in `tests/unit/test_memory_layer.py`
- adjust comments to match updated expectations

## Testing
- `PYTHONPATH=$(pwd)/juno-agent/src/phase2 pytest -q tests/unit/test_memory_layer.py` *(fails: Module 'MemoryLayer' missing methods)*

------
https://chatgpt.com/codex/tasks/task_e_68546345f7548327951ed42e23252a95