### PR TITLE
Move history section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [How JUNO Was Born](#how-juno-was-born-a-consultants-reckoning-with-the-genai-paradox)
+- [How JUNO Was Born](./docs/history.md)
 - [Why JUNO is Agentic AI, Not Just AI Agents](#why-juno-is-agentic-ai-not-just-ai-agents)
 - [Architecture](#architecture)
   - [Microservices Architecture](#microservices-architecture)
@@ -78,57 +78,10 @@
 
 ---
 
-## How JUNO Was Born: A Consultant's Reckoning with the GenAI Paradox
 
-When I joined the engineering team as a consultant, my brief was straightforward: help a seasoned manager bring maturity and optimization to a growing but strained software delivery operation. The team had energy, but also entropy—overwhelmed by dashboards, chasing defects across Jira, and struggling to distinguish signal from noise in daily standups. They didn't need another tool. They needed clarity.
+## How JUNO Was Born
 
-Around that same time, McKinsey released its strategy blueprint for agentic AI. As I read through their diagnosis of the *"genAI paradox"*—widespread deployment, minimal impact—it hit uncomfortably close to home. We had a multitude of dashboards, Jira data exports, and even a deployed Enterprise GPT instance. But none of it transformed how work got done. It hovered at the edges—bolted-on intelligence, not built-in intuition.
-
-> *"The real breakthrough comes in the vertical realm, where agentic AI enables the automation of complex business workflows… processes that were previously beyond the capabilities of first-generation gen AI tools."*  
-> — McKinsey & Company
-
-That was the permission I needed.
-
-JUNO began as a hypothesis:
-
-- What if we stopped asking AI to summarize Jira data, and instead asked it to think through Jira workflows?
-- What if we didn’t use GPT to assist managers with status updates, but empowered it to reason about engineering velocity, defect patterns, and delivery risk—just like a peer?
-
-JUNO is not a chatbot. It's not a dashboard filter.  
-It's an **Agentic AI Analyst**—built from the ground up to sit inside Jira and perform the mental gymnastics we were once forced to do manually:
-
-- Surface delivery anomalies before they show up in retros
-- Analyze defect sprawl in real time—not days after it derails release plans
-- Compress 12 browser tabs of context-switching into one insight thread
-
-Its architecture was inspired by McKinsey’s *agentic mesh model*—modular, vendor-neutral, observable, and designed to govern autonomy at scale. But JUNO didn’t emerge from a whiteboard. It was forged in the chaos of real engineering meetings—where delivery dates slip, scope expands, and everyone's underwater.
-
-And the more we built, the more one thing became obvious:
-
-> **JIRA wasn't the problem. The pricing and complexity were.**
-
-Enterprise-grade JIRA—especially when bundled with analytics plugins, Advanced Roadmaps, and multi-seat access—comes with high licensing costs and steep learning curves. Teams often pay for features they don’t use and navigate layers of tooling that don’t match their real workflow cadence.
-
-We didn’t want to add another plugin. We wanted to subtract complexity.
-
-So I asked: *What if the analyst was the interface?*
-
-By integrating with OpenAI’s **Enterprise GPT**, we created a more cost-conscious, usage-based alternative—scaling insight on demand without scaling licensing costs. GPT’s flexible consumption model meant we could meet teams where they were, without forcing them into tiered subscriptions or tool sprawl. For many teams, JUNO’s integration model is not just smarter—it’s **cheaper**.
-
----
-
-Now, when a manager asks:
-
-> _“Why did our regression rate spike last sprint?”_
-
-JUNO doesn’t just answer.
-
-It traces the root cause, correlates story estimates, maps test coverage, and recommends a path forward. Fast. Defensible. Context-aware.
-
-We didn’t build JUNO to experiment with AI.  
-We built JUNO because we were drowning in Jira—and no one was coming to save us.
-
----
+Curious about JUNO's origin story? Read the full background in [docs/history.md](./docs/history.md).
 
 ## Why JUNO is Agentic AI, Not Just AI Agents
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,52 @@
+## How JUNO Was Born: A Consultant's Reckoning with the GenAI Paradox
+
+When I joined the engineering team as a consultant, my brief was straightforward: help a seasoned manager bring maturity and optimization to a growing but strained software delivery operation. The team had energy, but also entropy—overwhelmed by dashboards, chasing defects across Jira, and struggling to distinguish signal from noise in daily standups. They didn't need another tool. They needed clarity.
+
+Around that same time, McKinsey released its strategy blueprint for agentic AI. As I read through their diagnosis of the *"genAI paradox"*—widespread deployment, minimal impact—it hit uncomfortably close to home. We had a multitude of dashboards, Jira data exports, and even a deployed Enterprise GPT instance. But none of it transformed how work got done. It hovered at the edges—bolted-on intelligence, not built-in intuition.
+
+> *"The real breakthrough comes in the vertical realm, where agentic AI enables the automation of complex business workflows… processes that were previously beyond the capabilities of first-generation gen AI tools."*  
+> — McKinsey & Company
+
+That was the permission I needed.
+
+JUNO began as a hypothesis:
+
+- What if we stopped asking AI to summarize Jira data, and instead asked it to think through Jira workflows?
+- What if we didn’t use GPT to assist managers with status updates, but empowered it to reason about engineering velocity, defect patterns, and delivery risk—just like a peer?
+
+JUNO is not a chatbot. It's not a dashboard filter.  
+It's an **Agentic AI Analyst**—built from the ground up to sit inside Jira and perform the mental gymnastics we were once forced to do manually:
+
+- Surface delivery anomalies before they show up in retros
+- Analyze defect sprawl in real time—not days after it derails release plans
+- Compress 12 browser tabs of context-switching into one insight thread
+
+Its architecture was inspired by McKinsey’s *agentic mesh model*—modular, vendor-neutral, observable, and designed to govern autonomy at scale. But JUNO didn’t emerge from a whiteboard. It was forged in the chaos of real engineering meetings—where delivery dates slip, scope expands, and everyone's underwater.
+
+And the more we built, the more one thing became obvious:
+
+> **JIRA wasn't the problem. The pricing and complexity were.**
+
+Enterprise-grade JIRA—especially when bundled with analytics plugins, Advanced Roadmaps, and multi-seat access—comes with high licensing costs and steep learning curves. Teams often pay for features they don’t use and navigate layers of tooling that don’t match their real workflow cadence.
+
+We didn’t want to add another plugin. We wanted to subtract complexity.
+
+So I asked: *What if the analyst was the interface?*
+
+By integrating with OpenAI’s **Enterprise GPT**, we created a more cost-conscious, usage-based alternative—scaling insight on demand without scaling licensing costs. GPT’s flexible consumption model meant we could meet teams where they were, without forcing them into tiered subscriptions or tool sprawl. For many teams, JUNO’s integration model is not just smarter—it’s **cheaper**.
+
+---
+
+Now, when a manager asks:
+
+> _“Why did our regression rate spike last sprint?”_
+
+JUNO doesn’t just answer.
+
+It traces the root cause, correlates story estimates, maps test coverage, and recommends a path forward. Fast. Defensible. Context-aware.
+
+We didn’t build JUNO to experiment with AI.  
+We built JUNO because we were drowning in Jira—and no one was coming to save us.
+
+---
+


### PR DESCRIPTION
## Summary
- move lengthy history narrative from README to `docs/history.md`
- link to the new history document from the README

## Testing
- `python -m pytest -q` *(fails: ImportError: cannot import name 'ReasoningLevel')*

------
https://chatgpt.com/codex/tasks/task_e_6854672bf52c8327b593211ce686dab3