### PR TITLE
Move visual showcase to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [Code Structure](#code-structure)
   - [Directory Overview](#directory-overview)
   - [Core Components](#core-components)
-- [Visual Interface Showcase](#visual-interface-showcase)
+- [Visual Interface Showcase](docs/visual-showcase.md)
   - [Phase-Specific Components](#phase-specific-components)
 - [Enterprise Deployment](#enterprise-deployment)
   - [Production Architecture](#production-architecture)
@@ -67,7 +67,7 @@
   - [Code Standards](#code-standards)
   - [Contribution Process](#contribution-process)
 - [License](#license)
-- [Visual Interface Showcase](##visual-interface-showcase)
+- [Visual Interface Showcase](docs/visual-showcase.md)
 - [Support](#support)
   - [Enterprise Support](#enterprise-support)
   - [Community Support](#community-support)
@@ -682,55 +682,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Visual Interface Showcase (Mockup only)
 
-*Professional engineering demonstration of JUNO's enterprise agentic AI platform*
-
-### Phase 1: Analytics Foundation
-*Foundational analytics and reporting capabilities with comprehensive Jira integration*
-
-<div align="center">
-<img src="docs/images/phase1-analytics-foundation.png" alt="JUNO Phase 1 Analytics Foundation" width="800"/>
-</div>
-
-### Phase 2: Agentic AI Management
-*Autonomous workflow management with memory systems and reasoning engines*
-
-<div align="center">
-
-#### Main Dashboard Overview
-*Comprehensive agentic AI monitoring with real-time metrics and autonomous decision tracking*
-
-<img src="docs/images/dashboard-overview.png" alt="JUNO Phase 2 Dashboard Overview" width="800"/>
-
-#### Memory Layer Interface
-*Four-layer memory system monitoring: Episodic, Semantic, Procedural, and Working Memory*
-
-<img src="docs/images/memory-layer-interface.png" alt="Memory Layer Monitoring Interface" width="800"/>
-
-#### Reasoning Engine Dashboard
-*Autonomous decision tracking with confidence scores and transparent audit trails*
-
-<img src="docs/images/reasoning-engine-dashboard.png" alt="Reasoning Engine Decision Tracking" width="800"/>
-
-#### Risk Forecasting Interface
-*Sprint risk predictions with probability scoring and mitigation recommendations*
-
-<img src="docs/images/risk-forecasting-interface.png" alt="Risk Forecasting Dashboard" width="800"/>
-
-</div>
-
-### Phase 3: Multi-Agent Orchestration
-*Distributed agent coordination with consensus protocols and fault tolerance*
-
-<div align="center">
-<img src="docs/images/phase3-orchestration-interface.png" alt="JUNO Phase 3 Multi-Agent Orchestration" width="800"/>
-</div>
-
-### Phase 4: AI-Native Operations
-*Autonomous operations with reinforcement learning and self-healing infrastructure*
-
-<div align="center">
-<img src="docs/images/phase4-ai-operations-interface.png" alt="JUNO Phase 4 AI-Native Operations" width="800"/>
-</div>
+For detailed screenshots and captions, see the [Visual Interface Showcase](docs/visual-showcase.md).
 
 ---
 

--- a/docs/visual-showcase.md
+++ b/docs/visual-showcase.md
@@ -1,0 +1,51 @@
+# Visual Interface Showcase (Mockup only)
+
+*Professional engineering demonstration of JUNO's enterprise agentic AI platform*
+
+### Phase 1: Analytics Foundation
+*Foundational analytics and reporting capabilities with comprehensive Jira integration*
+
+<div align="center">
+<img src="images/phase1-analytics-foundation.png" alt="JUNO Phase 1 Analytics Foundation" width="800"/>
+</div>
+
+### Phase 2: Agentic AI Management
+*Autonomous workflow management with memory systems and reasoning engines*
+
+<div align="center">
+
+#### Main Dashboard Overview
+*Comprehensive agentic AI monitoring with real-time metrics and autonomous decision tracking*
+
+<img src="images/dashboard-overview.png" alt="JUNO Phase 2 Dashboard Overview" width="800"/>
+
+#### Memory Layer Interface
+*Four-layer memory system monitoring: Episodic, Semantic, Procedural, and Working Memory*
+
+<img src="images/memory-layer-interface.png" alt="Memory Layer Monitoring Interface" width="800"/>
+
+#### Reasoning Engine Dashboard
+*Autonomous decision tracking with confidence scores and transparent audit trails*
+
+<img src="images/reasoning-engine-dashboard.png" alt="Reasoning Engine Decision Tracking" width="800"/>
+
+#### Risk Forecasting Interface
+*Sprint risk predictions with probability scoring and mitigation recommendations*
+
+<img src="images/risk-forecasting-interface.png" alt="Risk Forecasting Dashboard" width="800"/>
+
+</div>
+
+### Phase 3: Multi-Agent Orchestration
+*Distributed agent coordination with consensus protocols and fault tolerance*
+
+<div align="center">
+<img src="images/phase3-orchestration-interface.png" alt="JUNO Phase 3 Multi-Agent Orchestration" width="800"/>
+</div>
+
+### Phase 4: AI-Native Operations
+*Autonomous operations with reinforcement learning and self-healing infrastructure*
+
+<div align="center">
+<img src="images/phase4-ai-operations-interface.png" alt="JUNO Phase 4 AI-Native Operations" width="800"/>
+</div>


### PR DESCRIPTION
## Summary
- document the image-heavy visual showcase in a new docs page
- point README to the new page instead of embedding images

## Testing
- `python -m pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68546750e9788327b11019117d801cf6