### PR TITLE
Toned down phase readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ juno-repo/
 ## Phase Implementation
 
 ### Phase 1: Analytics Foundation
-**Status**: ✅ Production Ready  
+**Status**: 🚧 Prototype  
 **Capabilities**: Reactive analytics, insights, and reporting  
 **Deployment**: 2 weeks  
 **Use Case**: Establish baseline metrics and team adoption  
@@ -209,7 +209,7 @@ juno-repo/
 - System uptime: 99.95%
 
 ### Phase 2: Agentic Workflow Management
-**Status**: ✅ Production Ready  
+**Status**: 🚧 Prototype  
 **Capabilities**: Autonomous decision-making with governance oversight  
 **Deployment**: 6-8 weeks  
 **Use Case**: Transform workflows from reactive to proactive  
@@ -227,7 +227,7 @@ juno-repo/
 - System uptime: 99.97%
 
 ### Phase 3: Multi-Agent Orchestration
-**Status**: ✅ Production Ready  
+**Status**: 🚧 Prototype  
 **Capabilities**: Cross-team workflow coordination and distributed consensus  
 **Deployment**: 3-6 months  
 **Use Case**: Organization-wide workflow automation  
@@ -245,7 +245,7 @@ juno-repo/
 - Coordination efficiency: >95%
 
 ### Phase 4: AI-Native Operations
-**Status**: ✅ Production Ready  
+**Status**: 🚧 Prototype  
 **Capabilities**: Self-optimizing, self-healing operations  
 **Deployment**: 6-12 months  
 **Use Case**: Autonomous infrastructure and process optimization  

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,22 +112,22 @@ Choose your deployment path:
 ## JUNO Phases Overview
 
 ### Phase 1: Analytics Foundation
-- **Status**: ✅ Production Ready
+- **Status**: 🚧 Prototype
 - **Focus**: Immediate analytics value with existing Jira data
 - **Documentation**: [Phase 1 Deployment](./deployment/phase1-analytics-foundation.md)
 
 ### Phase 2: Agentic AI Workflow Management
-- **Status**: ✅ Production Ready
+- **Status**: 🚧 Prototype
 - **Focus**: Autonomous decision-making with governance oversight
 - **Documentation**: [Phase 2 Deployment](./deployment/phase2-agentic-ai.md)
 
 ### Phase 3: Multi-Agent Orchestration
-- **Status**: ✅ Production Ready
+- **Status**: 🚧 Prototype
 - **Focus**: Organization-wide workflow coordination
 - **Documentation**: [Phase 3 Deployment](./deployment/phase3-multi-agent-orchestration.md)
 
 ### Phase 4: AI-Native Operations
-- **Status**: ✅ Production Ready
+- **Status**: 🚧 Prototype
 - **Focus**: Autonomous infrastructure and operations management
 - **Documentation**: [Phase 4 Deployment](./deployment/phase4-ai-native-operations.md)
 
@@ -149,7 +149,7 @@ Choose your deployment path:
 - **API Documentation**: Auto-generated from code annotations
 - **Component Documentation**: Detailed README in each directory
 - **Architecture Diagrams**: Visual representations of system design
-- **Deployment Examples**: Production-ready configuration samples
+- **Deployment Examples**: reference configuration samples
 
 ## Getting Help
 

--- a/docs/deployment/phase3-multi-agent-orchestration.md
+++ b/docs/deployment/phase3-multi-agent-orchestration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Production-ready deployment infrastructure for JUNO Phase 3 Multi-Agent Orchestration with enterprise-grade monitoring, scaling, and fault tolerance.
+Reference deployment infrastructure for JUNO Phase 3 Multi-Agent Orchestration with enterprise-grade monitoring, scaling, and fault tolerance.
 
 ## Architecture
 
@@ -26,7 +26,7 @@ Production-ready deployment infrastructure for JUNO Phase 3 Multi-Agent Orchestr
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## Production Features
+## Key Features
 
 ### Consensus Protocol
 - **Raft-based distributed consensus** with leader election
@@ -321,7 +321,7 @@ docker version
 kubectl config current-context
 ```
 
-### Production Deployment
+### Reference Deployment
 ```bash
 # Clone repository
 git clone https://github.com/mj3b/juno.git

--- a/docs/deployment/phase4-ai-native-operations.md
+++ b/docs/deployment/phase4-ai-native-operations.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Production-ready deployment infrastructure for JUNO Phase 4 AI-Native Operations with self-optimizing, self-healing capabilities powered by reinforcement learning and advanced ML threat detection.
+Reference deployment infrastructure for JUNO Phase 4 AI-Native Operations with self-optimizing, self-healing capabilities powered by reinforcement learning and advanced ML threat detection.
 
 ## Architecture
 
@@ -27,7 +27,7 @@ Production-ready deployment infrastructure for JUNO Phase 4 AI-Native Operations
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## Production Features
+## Key Features
 
 ### Reinforcement Learning Optimizer
 - **Deep Q-Network (DQN)** for system optimization decisions
@@ -415,7 +415,7 @@ gpu:
     accelerator: nvidia-tesla-v100
 ```
 
-### Production Deployment
+### Reference Deployment
 ```bash
 # Deploy Phase 4 AI-Native Operations
 helm install juno-phase4 ./helm/phase4 \

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -35,7 +35,7 @@ After completing the quick start guide, you'll have:
 After completing the quick start:
 
 - **Explore Features**: Try different natural language queries and explore the dashboard
-- **Production Deployment**: Move to [Phase 2 Deployment Guide](../deployment/phase2-agentic-ai.md)
+- **Reference Deployment**: Move to [Phase 2 Deployment Guide](../deployment/phase2-agentic-ai.md)
 - **Enterprise Planning**: Review [Enterprise Implementation Strategy](../deployment/enterprise-implementation.md)
 - **Technical Deep Dive**: Study [System Architecture](../architecture/system-overview.md)
 

--- a/juno-agent/README.md
+++ b/juno-agent/README.md
@@ -24,10 +24,10 @@ juno-agent/
 
 | Directory | Purpose | Status |
 |-----------|---------|--------|
-| `src/phase1/` | Analytics foundation and Jira integration | ✅ Production Ready |
-| `src/phase2/` | Agentic AI workflow management | ✅ Production Ready |
-| `src/phase3/` | Multi-agent orchestration and consensus | ✅ Production Ready |
-| `src/phase4/` | AI-native operations and self-healing | ✅ Production Ready |
+| `src/phase1/` | Analytics foundation and Jira integration | ✅ Prototype |
+| `src/phase2/` | Agentic AI workflow management | ✅ Prototype |
+| `src/phase3/` | Multi-agent orchestration and consensus | ✅ Prototype |
+| `src/phase4/` | AI-native operations and self-healing | ✅ Prototype |
 | `requirements.txt` | Python dependencies for all phases | ✅ Current |
 
 ### Core Components (All Phases)
@@ -44,7 +44,7 @@ juno-agent/
 
 ### Phase 1: Analytics Foundation
 **Location**: `src/phase1/`
-**Status**: ✅ Production Ready
+**Status**: ✅ Prototype
 
 Core analytics and data processing components that establish the foundation for all subsequent phases.
 
@@ -52,7 +52,7 @@ Core analytics and data processing components that establish the foundation for 
 
 ### Phase 2: Agentic AI Workflow Management
 **Location**: `src/phase2/`
-**Status**: ✅ Production Ready
+**Status**: ✅ Prototype
 
 Core agentic AI components that enable autonomous decision-making with governance oversight.
 
@@ -60,7 +60,7 @@ Core agentic AI components that enable autonomous decision-making with governanc
 
 ### Phase 3: Multi-Agent Orchestration
 **Location**: `src/phase3/`
-**Status**: ✅ Production Ready
+**Status**: ✅ Prototype
 
 Distributed agent coordination with consensus protocols for organization-wide automation.
 
@@ -68,7 +68,7 @@ Distributed agent coordination with consensus protocols for organization-wide au
 
 ### Phase 4: AI-Native Operations
 **Location**: `src/phase4/`
-**Status**: ✅ Production Ready
+**Status**: ✅ Prototype
 
 Self-optimizing, self-healing operations with reinforcement learning and predictive scaling.
 

--- a/juno-agent/src/phase1/README.md
+++ b/juno-agent/src/phase1/README.md
@@ -4,7 +4,7 @@
 
 Phase 1 establishes the analytics foundation for JUNO, providing essential data extraction, analysis, and visualization capabilities. This phase creates the baseline metrics and team adoption necessary for subsequent agentic AI phases.
 
-**Status**: ✅ Production Ready  
+**Status**: ✅ Prototype  
 **Focus**: Reactive analytics, insights, and reporting  
 **Deployment Time**: 1-2 weeks  
 **Use Case**: Establish baseline metrics and team adoption
@@ -322,7 +322,7 @@ def migrate_phase1_to_phase2():
 
 ---
 
-**Phase Status**: ✅ Production Ready  
+**Phase Status**: ✅ Prototype  
 **Last Updated**: December 2024  
 **Version**: 1.0.0
 

--- a/juno-agent/src/phase2/README.md
+++ b/juno-agent/src/phase2/README.md
@@ -419,6 +419,6 @@ curl http://localhost:5000/api/v2/governance/status
 
 ---
 
-**Phase 2 Status**: ✅ Production Ready  
+**Phase 2 Status**: ✅ Prototype  
 **Next Phase**: [Phase 3 Multi-Agent Orchestration](../phase3/README.md)
 

--- a/juno-agent/src/phase3/README.md
+++ b/juno-agent/src/phase3/README.md
@@ -480,7 +480,7 @@ curl http://localhost:8080/api/v3/metrics/performance
 
 ---
 
-**Phase 3 Status**: ✅ Production Ready  
+**Phase 3 Status**: ✅ Prototype  
 **Previous Phase**: [Phase 2 Agentic AI](../phase2/README.md)  
 **Next Phase**: [Phase 4 AI-Native Operations](../phase4/README.md)
 

--- a/juno-agent/src/phase4/README.md
+++ b/juno-agent/src/phase4/README.md
@@ -512,7 +512,7 @@ curl http://localhost:8080/api/v4/threats/alerts
 
 ---
 
-**Phase 4 Status**: ✅ Production Ready  
+**Phase 4 Status**: ✅ Prototype  
 **Previous Phase**: [Phase 3 Multi-Agent Orchestration](../phase3/README.md)  
 **Enterprise Deployment**: [Enterprise Implementation Guide](../../../docs/deployment/enterprise-implementation.md)
 

--- a/src/juno/core/memory/README.md
+++ b/src/juno/core/memory/README.md
@@ -419,6 +419,6 @@ curl http://localhost:5000/api/v2/governance/status
 
 ---
 
-**Phase 2 Status**: ✅ Production Ready  
+**Phase 2 Status**: ✅ Prototype  
 **Next Phase**: [Phase 3 Multi-Agent Orchestration](../phase3/README.md)
 


### PR DESCRIPTION
## Summary
- adjust readiness language in README and docs
- update phase documentation under deployment guides
- apply the same updates to internal phase READMEs

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ReasoningLevel' from 'reasoning_engine')*

------
https://chatgpt.com/codex/tasks/task_e_6854675bdfa48327a17539cc920d4774