### PR TITLE
Refine quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,56 +266,23 @@ juno-repo/
 
 ## Quick Start
 
-### Prerequisites
-
-- Python 3.11+
-- Docker and Docker Compose
-- Kubernetes cluster (for production)
-- **Cloud Jira instance** (recommended for optimal performance and security) - [Cloud Jira Setup Guide](./docs/deployment/cloud-jira-deployment.md)
-- OpenAI API key (see [Enterprise GPT Integration Guide](./docs/reference/enterprise-gpt-integration.md))
-
-### Local Development Setup
+A minimal setup to launch JUNO locally. For the full environment setup and
+detailed instructions, see the
+[Quick Start guide](./docs/getting-started/quick-start.md).
 
 ```bash
 # Clone repository
 git clone https://github.com/mj3b/juno.git
 cd juno
 
-# One-click deployment
+# Install dependencies and prepare the environment
 ./deploy.sh
 
-# Start JUNO Phase 2
+# Start JUNO Phase 2 locally
 ./start_juno.sh
 
-# Access dashboard
+# Open the dashboard
 open http://localhost:5000
-```
-
-### Configuration
-
-```bash
-# Copy environment template
-cp .env.phase2.example .env
-
-# Configure required settings
-export OPENAI_API_KEY="your-openai-key"  # See Enterprise GPT Integration Guide
-export JIRA_URL="https://your-company.atlassian.net"  # Cloud Jira URL
-export JIRA_USERNAME="your-email@company.com"  # Cloud Jira email
-export JIRA_API_TOKEN="your-api-token"  # Cloud Jira API token
-export JUNO_PHASE=2
-```
-
-### Verification
-
-```bash
-# Run comprehensive test suite
-python -m pytest tests/ -v
-
-# Check system health
-./health_check.sh
-
-# Run demo scenarios
-python demo_scenarios.py
 ```
 
 ## Code Structure

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -25,6 +25,9 @@ source venv/bin/activate  # Linux/Mac
 
 # Install dependencies
 pip install -r juno-agent/requirements.txt
+
+# For a one-click setup you can also run:
+./deploy.sh
 ```
 
 ### Step 2: Configure (5 minutes)
@@ -62,6 +65,11 @@ python juno-agent/src/phase2/quick_setup.py
 
 # Run tests to verify installation
 python juno-agent/src/phase2/test_suite.py --quick
+
+# Optional full verification
+python -m pytest tests/ -v
+./health_check.sh
+python demo_scenarios.py
 ```
 
 ### Step 4: Start Services (1 minute)
@@ -69,6 +77,9 @@ python juno-agent/src/phase2/test_suite.py --quick
 ```bash
 # Start JUNO Phase 2
 python juno-agent/app.py --phase=2
+
+# Or use the helper script
+./start_juno.sh
 
 # Open browser to http://localhost:5000
 ```


### PR DESCRIPTION
## Summary
- shorten the quick start in README
- move environment details into docs/getting-started/quick-start.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68546767b7308327b3c89948e7deba92