### PR TITLE
Fix README badges and update test report

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <img src="docs/images/juno-readme-banner-rectangular.png" alt="JUNO - Agentic AI Platform for Jira Intelligence" width="100%"/>
 </div>
 
-[![Tests](https://img.shields.io/badge/tests-109%20passed-brightgreen.svg)](./tests/TEST_RESULTS.md)
-[![Coverage](https://img.shields.io/badge/coverage-96.3%25-green.svg)](./tests/)
+[![Tests](https://img.shields.io/badge/tests-5%20passed-brightgreen.svg)](./tests/TEST_RESULTS.md)
+[![Coverage](https://img.shields.io/badge/coverage-N/A-lightgrey.svg)](./tests/)
 [![Performance](https://img.shields.io/badge/latency-127ms%20avg-blue.svg)](./tests/TEST_RESULTS.md)
 [![Phase](https://img.shields.io/badge/phases-1--4%20ready-orange.svg)](./docs/)
 [![Enterprise](https://img.shields.io/badge/enterprise-ready-purple.svg)](./docs/deployment/enterprise-implementation.md)
@@ -561,9 +561,7 @@ python -m pytest tests/test_performance/ -v # Performance tests
 
 ### Test Results
 
-The automated test suite is presently incomplete and fails during collection. See
-[`tests/TEST_RESULTS.md`](./tests/TEST_RESULTS.md) for additional context. Contributions
-to restore comprehensive testing are welcome.
+The project currently includes a small smoke suite. Running `pytest` yields five passing tests and twelve skipped. See [`tests/TEST_RESULTS.md`](./tests/TEST_RESULTS.md) for the full report.
 
 ## Contributing
 

--- a/tests/TEST_RESULTS.md
+++ b/tests/TEST_RESULTS.md
@@ -4,11 +4,16 @@
 
 * **Date:** June 19, 2025
 * **Environment:** Local development container
-* **Total Tests Collected:** 0
-* **Import Errors:** 11
-* **Tests Executed:** 0
-* **Success Rate:** 0%
+* **Total Tests Collected:** 17
+* **Tests Executed:** 5
+* **Tests Skipped:** 12
+* **Import Errors:** 0
+* **Success Rate:** 100%
 
-The current test suite fails during collection due to missing dependencies.
-Once the necessary modules are available, this file should be updated with
-accurate metrics.
+All available unit tests execute successfully. Several additional tests are marked
+as skipped due to missing optional dependencies. See below for the pytest output.
+
+```
+$ pytest -q
+5 passed, 12 skipped in 0.12s
+```


### PR DESCRIPTION
## Summary
- update badges to show 5 passing tests and no coverage data
- clarify in README that only a small smoke test suite runs
- refresh TEST_RESULTS with current pytest output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854887e7b788327b5abdf1b7e88a4fc