### PR TITLE
Add Phase 2 test defect diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ juno-repo/
 - **Reasoning Engine**: Multi-factor confidence scoring with audit trails
 - **Risk Forecasting**: Predictive analytics with 89%+ accuracy
 - **Governance Framework**: Role-based approval workflows
+- **Test Defect Diagnostics**: Automatic analysis of failing tests
 
 **Performance Metrics**:
 - Decision latency: 127ms average

--- a/juno-agent/src/phase2/defect_diagnostics.py
+++ b/juno-agent/src/phase2/defect_diagnostics.py
@@ -1,0 +1,78 @@
+"""Test Defect Diagnostics Module for JUNO Phase 2.
+
+This module analyzes test results and categorizes failures to assist
+with root cause identification.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TestCaseResult:
+    """Represents a single test case result."""
+    name: str
+    status: str
+    error: str | None = None
+
+
+@dataclass
+class DiagnosticsReport:
+    """Aggregated diagnostics for a set of test results."""
+    total_tests: int
+    passed: int
+    failed: int
+    failure_rate: float
+    failure_categories: Dict[str, int] = field(default_factory=dict)
+    example_failures: List[Dict[str, str]] = field(default_factory=list)
+
+
+class TestDefectDiagnostics:
+    """Analyze test results and produce defect diagnostics."""
+
+    def analyze(self, results: List[TestCaseResult]) -> DiagnosticsReport:
+        total = len(results)
+        passed = len([r for r in results if r.status.upper() == "PASS"])
+        failed_cases = [r for r in results if r.status.upper() == "FAIL"]
+        failed = len(failed_cases)
+        failure_rate = failed / total * 100 if total else 0.0
+
+        categories: Dict[str, int] = {}
+        examples: List[Dict[str, str]] = []
+
+        for case in failed_cases:
+            if case.error:
+                category = case.error.split(":", 1)[0]
+            else:
+                category = "UnknownError"
+            categories[category] = categories.get(category, 0) + 1
+            if len(examples) < 5:
+                examples.append({"test": case.name, "error": case.error or ""})
+
+        report = DiagnosticsReport(
+            total_tests=total,
+            passed=passed,
+            failed=failed,
+            failure_rate=round(failure_rate, 2),
+            failure_categories=categories,
+            example_failures=examples,
+        )
+
+        logger.info(
+            "Generated test defect diagnostics: %s failed/%s total",
+            failed,
+            total,
+        )
+        return report
+
+
+if __name__ == "__main__":
+    sample = [
+        TestCaseResult(name="test_example", status="FAIL", error="AssertionError: expected 1"),
+        TestCaseResult(name="test_ok", status="PASS"),
+    ]
+    diag = TestDefectDiagnostics().analyze(sample)
+    print(diag)

--- a/tests/unit/test_defect_diagnostics.py
+++ b/tests/unit/test_defect_diagnostics.py
@@ -1,0 +1,27 @@
+"""Unit tests for TestDefectDiagnostics."""
+import unittest
+import sys
+
+sys.path.append('juno-agent/src/phase2')
+
+from defect_diagnostics import TestDefectDiagnostics, TestCaseResult
+
+
+class TestDiagnosticsModule(unittest.TestCase):
+    def test_basic_analysis(self):
+        diagnostics = TestDefectDiagnostics()
+        sample = [
+            TestCaseResult(name="a", status="PASS"),
+            TestCaseResult(name="b", status="FAIL", error="AssertionError: boom"),
+            TestCaseResult(name="c", status="FAIL", error="TimeoutError: slow"),
+        ]
+        report = diagnostics.analyze(sample)
+        self.assertEqual(report.passed, 1)
+        self.assertEqual(report.failed, 2)
+        self.assertAlmostEqual(report.failure_rate, 66.67, places=1)
+        self.assertIn("AssertionError", report.failure_categories)
+        self.assertIn("TimeoutError", report.failure_categories)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add defect diagnostic module for Phase 2
- integrate diagnostics into Phase 2 test suite
- provide unit test for defect diagnostics
- document test defect diagnostics in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ac50e4a483278a7291eec9652533