### PR TITLE
Add diagram captions and phase overview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,16 @@ Choose your deployment path:
 
 ## JUNO Phases Overview
 
+```mermaid
+graph LR
+    P1[Phase 1<br/>Analytics Foundation]
+    P2[Phase 2<br/>Agentic Workflows]
+    P3[Phase 3<br/>Multi-Agent Orchestration]
+    P4[Phase 4<br/>AI-Native Operations]
+    P1 --> P2 --> P3 --> P4
+```
+*Figure: Phase evolution overview.*
+
 ### Phase 1: Analytics Foundation
 - **Status**: 🚧 Prototype
 - **Focus**: Immediate analytics value with existing Jira data

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -35,6 +35,7 @@ graph TB
     Backend -->|Results| UI
     UI -->|Visualization| User
 ```
+*Figure: High-level system architecture.*
 
 ---
 

--- a/docs/guides/ai-agents-vs-agentic-ai.md
+++ b/docs/guides/ai-agents-vs-agentic-ai.md
@@ -41,6 +41,7 @@ graph TB
     JUNO -->|Multiple Valid Paths| Solutions[✅ Optimal Solutions]
     Solutions -->|Outcome Validation| User
 ```
+*Figure 1: Agentic AI system architecture.*
 
 ## JUNO Evolution Timeline
 
@@ -60,6 +61,7 @@ graph LR
     P3 --> F3[🎼 Lead Orchestrator<br/>🤝 Specialized Sub-agents<br/>🔄 Consensus Mechanisms]
     P4 --> F4[🔮 Self-Healing<br/>📈 Reinforcement Learning<br/>🛡️ Threat Detection]
 ```
+*Figure 2: Evolution across JUNO phases.*
 
 ## Traditional AI Agents vs JUNO Agentic AI
 
@@ -96,6 +98,7 @@ graph TB
     
     Traditional -.->|Evolution| Agentic
 ```
+*Figure 3: Traditional agents vs agentic AI.*
 
 ## JUNO Human Evaluation Framework
 
@@ -153,6 +156,7 @@ graph TB
     
     Feedback --> JUNO
 ```
+*Figure 4: Multilayer human evaluation framework.*
 
 ## Outcome-Focused Evaluation Process
 
@@ -183,6 +187,7 @@ graph LR
     
     Outcome --> Success[✅ Risk Mitigated<br/>✅ Issues Resolved<br/>✅ Workflow Optimized]
 ```
+*Figure 5: Outcome-focused evaluation flow.*
 
 ## JUNO Supervisor Roles and Responsibilities
 
@@ -220,6 +225,7 @@ graph TB
     
     Integration --> Cycles[📅 Review Cycles<br/>• Weekly Reviews<br/>• Monthly Assessment<br/>• Quarterly Evaluation<br/>• Continuous Improvement]
 ```
+*Figure 6: Supervisor roles and focus areas.*
 
 ## Phase-Specific Evaluation Criteria
 
@@ -260,6 +266,7 @@ graph TB
     
     Evaluation --> Outcome[✅ Continuous Value Delivery]
 ```
+*Figure 7: Phase-specific evaluation metrics.*
 
 ## Implementation Roadmap for Human Evaluation
 


### PR DESCRIPTION
## Summary
- add captions to system overview and AI agents vs. agentic AI diagrams
- add a phase evolution diagram in docs README
- verify rendering with Grip markdown preview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `grip docs/guides/ai-agents-vs-agentic-ai.md --export /tmp/guide.html`
- `grip docs/architecture/system-overview.md --export /tmp/overview.html`
- `grip docs/README.md --export /tmp/readme.html`


------
https://chatgpt.com/codex/tasks/task_e_6854c7f9ae0c8327b0802dfb02b98bb5