### PR TITLE
Replace Atlassian Cloud references with Jira Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **JUNO: AI-driven analytics for Jira.** This repository hosts the agentic platform that augments Jira with natural language queries and data-driven insights. Built on Enterprise GPT, JUNO translates Jira activity into actionable reports covering defects, velocity trends, and project health. Ask questions in plain English to obtain rigorous answers backed by your issue tracker.
 
-**Optimized for Atlassian Cloud**: JUNO is designed for secure, high-performance deployments. It leverages Atlassian's APIs and cloud-native practices to integrate seamlessly with enterprise environments.
+**Optimized for Jira Cloud**: JUNO is designed for secure, high-performance deployments. It leverages Jira Cloud's APIs and cloud-native practices to integrate seamlessly with enterprise environments.
 <div style="background-color:#fff5b1;border:1px solid #ffe58f;border-radius:6px;padding:12px;margin-top:8px;margin-bottom:8px"><b>Important Notes:</b> JUNO leverages advanced generative AI. Review the <a href="./docs/architecture/technical-specifications.md">technical specifications</a> and <a href="./docs/deployment/enterprise-implementation.md">enterprise implementation guide</a> before deploying in production.</div>
 
 For full documentation and deployment guides, see the [docs directory](./docs/).

--- a/docs/deployment/cloud-jira-deployment.md
+++ b/docs/deployment/cloud-jira-deployment.md
@@ -24,15 +24,15 @@
 
 ## Overview
 
-This comprehensive guide provides enterprise-grade deployment patterns for JUNO with Atlassian Cloud Jira. Cloud Jira offers significant advantages for agentic AI implementations, including enhanced API performance, automatic updates, robust security frameworks, and seamless scalability that aligns perfectly with JUNO's enterprise architecture.
+This comprehensive guide provides enterprise-grade deployment patterns for JUNO with Jira Cloud. Cloud Jira offers significant advantages for agentic AI implementations, including enhanced API performance, automatic updates, robust security frameworks, and seamless scalability that aligns perfectly with JUNO's enterprise architecture.
 
-JUNO's cloud-native design leverages Atlassian Cloud's infrastructure to deliver optimal performance, security, and reliability for enterprise agentic AI workflows. This guide covers deployment strategies from analytics foundation through AI-native operations, with specific optimizations for cloud environments.
+JUNO's cloud-native design leverages Jira Cloud's infrastructure to deliver optimal performance, security, and reliability for enterprise agentic AI workflows. This guide covers deployment strategies from analytics foundation through AI-native operations, with specific optimizations for cloud environments.
 
 ## Cloud Jira Advantages
 
 ### Enhanced API Performance and Reliability
 
-Atlassian Cloud provides superior API performance compared to on-premises installations, with guaranteed uptime SLAs and global content delivery networks that reduce latency for JUNO's data extraction and analysis operations. The cloud infrastructure offers automatic load balancing and traffic distribution that ensures consistent performance even during peak usage periods.
+Jira Cloud provides superior API performance compared to on-premises installations, with guaranteed uptime SLAs and global content delivery networks that reduce latency for JUNO's data extraction and analysis operations. The cloud infrastructure offers automatic load balancing and traffic distribution that ensures consistent performance even during peak usage periods.
 
 Cloud Jira's REST API endpoints are optimized for high-throughput operations, making them ideal for JUNO's continuous data processing requirements. The platform provides rate limiting that is more generous than typical on-premises configurations, allowing JUNO to perform comprehensive analytics without throttling concerns. Additionally, webhook delivery is more reliable in cloud environments, ensuring that JUNO receives real-time updates for proactive workflow management.
 
@@ -40,15 +40,15 @@ The cloud platform's automatic scaling capabilities mean that API performance re
 
 ### Automatic Updates and Compatibility
 
-One of the most significant advantages of cloud Jira for JUNO deployment is the elimination of version compatibility concerns. Atlassian Cloud automatically updates to the latest versions, ensuring that JUNO always has access to the newest API features and security enhancements without requiring manual intervention or compatibility testing.
+One of the most significant advantages of cloud Jira for JUNO deployment is the elimination of version compatibility concerns. Jira Cloud automatically updates to the latest versions, ensuring that JUNO always has access to the newest API features and security enhancements without requiring manual intervention or compatibility testing.
 
-This automatic update mechanism is particularly valuable for agentic AI systems that rely on consistent API behavior and feature availability. JUNO's integration patterns are designed to leverage the latest Atlassian Cloud capabilities, and automatic updates ensure that these features remain available without deployment disruptions.
+This automatic update mechanism is particularly valuable for agentic AI systems that rely on consistent API behavior and feature availability. JUNO's integration patterns are designed to leverage the latest Jira Cloud capabilities, and automatic updates ensure that these features remain available without deployment disruptions.
 
 The cloud platform's backward compatibility guarantees mean that existing JUNO integrations continue to function seamlessly even as new features are introduced. This provides a stable foundation for long-term agentic AI operations while ensuring access to the latest capabilities for enhanced functionality.
 
 ### Enterprise Security Framework
 
-Atlassian Cloud provides enterprise-grade security that complements JUNO's security architecture. The platform includes SOC 2 Type II compliance, ISO 27001 certification, and GDPR compliance built into the infrastructure, reducing the security configuration burden for JUNO deployments.
+Jira Cloud provides enterprise-grade security that complements JUNO's security architecture. The platform includes SOC 2 Type II compliance, ISO 27001 certification, and GDPR compliance built into the infrastructure, reducing the security configuration burden for JUNO deployments.
 
 Cloud Jira's security features include advanced threat detection, automated security monitoring, and enterprise-grade encryption that aligns with JUNO's security requirements. The platform provides centralized identity management through integration with enterprise identity providers, enabling seamless single sign-on and role-based access control for JUNO users.
 
@@ -68,7 +68,7 @@ Cloud Jira's disaster recovery and business continuity capabilities ensure that 
 
 ### Cloud-Native JUNO Architecture
 
-The cloud-native JUNO architecture is specifically designed to leverage Atlassian Cloud's infrastructure capabilities while maintaining the flexibility and scalability required for enterprise agentic AI operations. This architecture pattern emphasizes microservices design, containerized deployment, and cloud-native security practices that align with modern enterprise requirements.
+The cloud-native JUNO architecture is specifically designed to leverage Jira Cloud's infrastructure capabilities while maintaining the flexibility and scalability required for enterprise agentic AI operations. This architecture pattern emphasizes microservices design, containerized deployment, and cloud-native security practices that align with modern enterprise requirements.
 
 The architecture utilizes Kubernetes orchestration for container management, with automatic scaling policies that respond to workload demands. This ensures that JUNO's agentic AI operations maintain optimal performance during peak usage periods while minimizing resource costs during low-activity periods. The cloud-native design also enables seamless integration with enterprise monitoring and observability platforms.
 
@@ -104,9 +104,9 @@ The hybrid pattern includes secure connectivity between on-premises JUNO compone
 
 ### Cloud Jira Instance Requirements
 
-Before deploying JUNO with cloud Jira, ensure that your Atlassian Cloud instance meets the minimum requirements for enterprise agentic AI operations. Your cloud Jira instance should be configured with appropriate user licenses, project permissions, and API access controls that support JUNO's operational requirements.
+Before deploying JUNO with cloud Jira, ensure that your Jira Cloud instance meets the minimum requirements for enterprise agentic AI operations. Your cloud Jira instance should be configured with appropriate user licenses, project permissions, and API access controls that support JUNO's operational requirements.
 
-The cloud Jira instance should include administrative access for JUNO configuration, including the ability to create custom fields, configure webhooks, and manage user permissions. Additionally, ensure that your Atlassian Cloud subscription includes sufficient API rate limits for JUNO's data processing requirements.
+The cloud Jira instance should include administrative access for JUNO configuration, including the ability to create custom fields, configure webhooks, and manage user permissions. Additionally, ensure that your Jira Cloud subscription includes sufficient API rate limits for JUNO's data processing requirements.
 
 Verify that your cloud Jira instance has the necessary apps and integrations enabled for your specific use cases. JUNO works optimally with standard Jira configurations, but some advanced features may require specific Atlassian Marketplace apps or custom configurations.
 
@@ -128,7 +128,7 @@ Configure persistent storage with appropriate backup and disaster recovery capab
 
 ### Network and Security Configuration
 
-Cloud JUNO deployment requires network configuration that supports secure communication with Atlassian Cloud while maintaining enterprise security standards. Configure firewall rules that allow HTTPS traffic to Atlassian Cloud endpoints while restricting unnecessary network access.
+Cloud JUNO deployment requires network configuration that supports secure communication with Jira Cloud while maintaining enterprise security standards. Configure firewall rules that allow HTTPS traffic to Jira Cloud endpoints while restricting unnecessary network access.
 
 Implement network segmentation that isolates JUNO components from other enterprise systems while enabling necessary integrations. This approach minimizes security risks while ensuring that JUNO can access required resources for optimal operation.
 
@@ -423,7 +423,7 @@ data:
 
 ### Cloud-Native Security Architecture
 
-Cloud Jira deployment leverages Atlassian Cloud's enterprise security framework while implementing additional security layers specific to agentic AI operations. This comprehensive security approach ensures that JUNO operations maintain the highest security standards while enabling autonomous decision-making capabilities.
+Cloud Jira deployment leverages Jira Cloud's enterprise security framework while implementing additional security layers specific to agentic AI operations. This comprehensive security approach ensures that JUNO operations maintain the highest security standards while enabling autonomous decision-making capabilities.
 
 The security architecture includes multiple layers of protection, including network security, application security, data security, and operational security. Each layer is designed to work together to provide comprehensive protection against security threats while maintaining operational efficiency.
 
@@ -966,13 +966,13 @@ Regular performance reviews and optimization cycles ensure that system performan
 
 ## References
 
-[1] Atlassian Cloud Security Documentation: https://www.atlassian.com/trust/security
+[1] Jira Cloud Security Documentation: https://www.atlassian.com/trust/security
 [2] Kubernetes Best Practices Guide: https://kubernetes.io/docs/concepts/
 [3] OpenAI Enterprise API Documentation: https://platform.openai.com/docs/
 [4] JUNO Architecture Documentation: https://github.com/mj3b/juno/docs/architecture/
 [5] Cloud Native Computing Foundation Guidelines: https://www.cncf.io/
 [6] Enterprise Security Framework Standards: https://www.nist.gov/cyberframework
-[7] Atlassian Cloud API Documentation: https://developer.atlassian.com/cloud/jira/platform/
+[7] Jira Cloud API Documentation: https://developer.atlassian.com/cloud/jira/platform/
 [8] Container Security Best Practices: https://kubernetes.io/docs/concepts/security/
 [9] Microservices Architecture Patterns: https://microservices.io/patterns/
 [10] Enterprise Compliance Framework Guidelines: https://www.iso.org/iso-27001-information-security.html

--- a/docs/reference/enterprise-gpt-integration.md
+++ b/docs/reference/enterprise-gpt-integration.md
@@ -54,7 +54,7 @@ This guide provides enterprise-grade patterns for integrating OpenAI's GPT model
 
 ### Overview
 
-Cloud Jira provides optimal infrastructure for Enterprise GPT integrations with JUNO, offering enhanced API performance, automatic updates, and enterprise-grade security that complements OpenAI's capabilities. This section provides specific guidance for implementing GPT integrations with Atlassian Cloud.
+Cloud Jira provides optimal infrastructure for Enterprise GPT integrations with JUNO, offering enhanced API performance, automatic updates, and enterprise-grade security that complements OpenAI's capabilities. This section provides specific guidance for implementing GPT integrations with Jira Cloud.
 
 ### Cloud Jira Advantages for GPT Integration
 
@@ -289,7 +289,7 @@ class CloudJiraDataPipeline:
         
         return template.format(
             data=enhanced_data,
-            data_source="Atlassian Cloud",
+            data_source="Jira Cloud",
             processing_timestamp=datetime.utcnow().isoformat(),
             data_count=len(enhanced_data)
         )
@@ -1843,7 +1843,7 @@ class CloudJiraGPTOptimizer:
         
         # Cloud Jira provides richer metadata
         cloud_enhancements = {
-            'data_source': 'Atlassian Cloud',
+            'data_source': 'Jira Cloud',
             'api_version': '3',
             'enhanced_fields': True,
             'real_time_data': True,
@@ -2254,7 +2254,7 @@ class CloudMigrationManager:
             {prompt_template}
             
             Cloud Enhancements:
-            - Enhanced field data available from Atlassian Cloud
+            - Enhanced field data available from Jira Cloud
             - Real-time webhook data for immediate processing
             - Global team distribution considerations
             - Automatic platform updates ensure latest features
@@ -2276,5 +2276,5 @@ class CloudMigrationManager:
         }
 ```
 
-This comprehensive cloud Jira integration section provides engineers with specific guidance for implementing Enterprise GPT integrations with Atlassian Cloud, including configuration examples, performance optimizations, security considerations, and migration strategies that leverage cloud-native capabilities for optimal JUNO deployment.
+This comprehensive cloud Jira integration section provides engineers with specific guidance for implementing Enterprise GPT integrations with Jira Cloud, including configuration examples, performance optimizations, security considerations, and migration strategies that leverage cloud-native capabilities for optimal JUNO deployment.
 

--- a/src/juno/infrastructure/README.md
+++ b/src/juno/infrastructure/README.md
@@ -17,7 +17,7 @@ infrastructure/
 ### Jira Integration (`jira_integration/`)
 - **connector.py**: Jira Cloud API client
 - **extractor.py**: Data extraction and transformation
-- **Cloud Optimization**: Enhanced for Atlassian Cloud performance
+- **Cloud Optimization**: Enhanced for Jira Cloud performance
 
 ### OpenAI Integration (`openai_integration/`)
 - **connector.py**: Enterprise GPT connector


### PR DESCRIPTION
## Summary
- swap references of Atlassian Cloud to Jira Cloud across docs
- adjust infrastructure readme and main README for Jira Cloud

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859820d2ee0832799755b3f716942d3